### PR TITLE
Show button for new users for one week

### DIFF
--- a/src/resources/views/dashboardButtons.blade.php
+++ b/src/resources/views/dashboardButtons.blade.php
@@ -1,4 +1,4 @@
-@if ($projects->isEmpty())
+@if ($projects->isEmpty() || auth()->user()->created_at->gt(now()->subWeek()))
     @can ('create', Biigle\Project::class)
         <form role="form" method="POST" action="{{ url('api/v1/projects/demo') }}" style="margin-top: 5px;display:inline-block;">
             <input type="hidden" name="_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
1. Shows demo project button to new users
2. Allows users created within the last week to see the demo project button even if they already belong to a project.
3. After one week, still keep showing it only when the user has no projects.

Fixes #12 